### PR TITLE
initial support for Go

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: go
+
+go:
+  - "1.10"
+
+go_import_path: github.com/rd235/libslirp

--- a/README.md
+++ b/README.md
@@ -62,3 +62,35 @@ To terminate the slirp network, call:
 ```
 slirp_close(myslirp)
 ```
+
+## Go binding
+
+To install the Go binding, you just need to run `go get github.com/rd235/libslirp/src`.
+No need to run `./configure` and `make`.
+
+Usage:
+
+```go
+package main
+
+import libslirp "github.com/rd235/libslirp/src"
+
+func main(){
+  slirp, _ := libslirp.Open(libslirp.IPv4)
+  slirp.Start()
+  slirp.Write(ethBytes)
+  reply := make([]byte, 4096)
+  slirp.Read(reply)
+  ...
+  slirp.Close()
+}
+```
+
+See also [godoc](https://godoc.org/github.com/rd235/libslirp/src).
+
+### Unit testing
+
+```
+$ go get -t -u github.com/rd235/libslirp/src
+$ go test -v github.com/rd235/libslirp/src
+```

--- a/src/libslirp.go
+++ b/src/libslirp.go
@@ -1,0 +1,393 @@
+// Package libslirp provides Go-binding for libslirp.
+package libslirp
+
+// FIXME: move this package to the top directory (how? https://stackoverflow.com/questions/28881072/how-to-add-c-files-in-a-subdirectory-as-part-of-go-build-by-using-pseudo-cgo-dir)
+
+import (
+	//#cgo CFLAGS: -Wall -O2 -I${SRCDIR} -I${SRCDIR}/../include
+	//#cgo LDFLAGS: -lpthread
+	//#include <stdlib.h>
+	//#include <arpa/inet.h>
+	//#include "include/libslirp.h"
+	"C"
+	"errors"
+	"fmt"
+	"net"
+	"strconv"
+	"unsafe"
+)
+
+// Slirp represents a Slirp virtual network instance.
+// Slirp implements io.ReadWriteCloser interface.
+type Slirp struct {
+	p                 *C.struct_slirp
+	addr, addr6       *net.IPNet
+	dnsaddr, dnsaddr6 net.IP
+	forwards          map[net.Addr]net.Addr
+	unixForwards      map[net.Addr]string
+}
+
+const (
+	flagIPv4       = 0x01
+	flagIPv6       = 0x02
+	flagRestricted = 0x10
+)
+
+var (
+	// DefaultAddr is the default IPv4 address.
+	DefaultAddr = &net.IPNet{
+		// NOTE: net.ParseIP("x.y.z.w") returns 16-byte net.IP, even for IPv4 address.
+		// To4 ensures the result to be 4-byte.
+		IP:   net.ParseIP("10.0.2.2").To4(),
+		Mask: net.CIDRMask(24, 32),
+	}
+	// DefaultAddr is the default IPv6 address.
+	DefaultAddr6 = &net.IPNet{
+		IP:   net.ParseIP("fe80::2"),
+		Mask: net.CIDRMask(64, 128),
+	}
+	// DefaultDNSAddr is the default IPv4 DNS address.
+	DefaultDNSAddr = net.ParseIP("10.0.2.3")
+	// DefaultDNSAddr6 is the default IPv6 DNS address.
+	DefaultDNSAddr6 = net.ParseIP("fe80::3")
+)
+
+// Opts is options for New.
+type Opts struct {
+	// EnableIPv4 enables IPv4.
+	EnableIPv4 bool
+	// EnableIPv4 enables IPv6.
+	EnableIPv6 bool
+	// Restricted to the host only.
+	Restricted bool
+}
+
+// New opens the slirp network.
+// If opts is nil or empty, enabling IPv4 in non-restricted mode is assumed.
+// The caller needs to call Start() manually.
+func New(opts *Opts) (*Slirp, error) {
+	flags := 0
+	if opts != nil {
+		if opts.EnableIPv4 {
+			flags |= flagIPv4
+		}
+		if opts.EnableIPv6 {
+			flags |= flagIPv6
+		}
+		if opts.Restricted {
+			flags |= flagRestricted
+		}
+	}
+	slirp, err := C.slirp_open(C.uint(flags))
+	if err != nil {
+		return nil, err
+	}
+	if slirp == nil {
+		return nil, errors.New("slirp_open returned NULL")
+	}
+	// no need to pass the default config to slirp explicitly.
+	return &Slirp{
+		p:            slirp,
+		addr:         DefaultAddr,
+		addr6:        DefaultAddr6,
+		dnsaddr:      DefaultDNSAddr,
+		dnsaddr6:     DefaultDNSAddr6,
+		forwards:     make(map[net.Addr]net.Addr, 0),
+		unixForwards: make(map[net.Addr]string, 0),
+	}, nil
+}
+
+// Start starts the slirp network.
+func (slirp *Slirp) Start() error {
+	rc, err := C.slirp_start(slirp.p)
+	if err != nil {
+		return err
+	}
+	if rc != 0 {
+		return fmt.Errorf("slirp_start returned status %d", int(rc))
+	}
+	return err
+}
+
+// Read receives an Ethernet packet.
+func (slirp *Slirp) Read(p []byte) (int, error) {
+	n, err := C.slirp_recv(slirp.p, unsafe.Pointer(&p[0]), C.ulong(len(p)))
+	return int(n), err
+}
+
+// Write sends an Ethernet packet.
+func (slirp *Slirp) Write(p []byte) (int, error) {
+	n, err := C.slirp_send(slirp.p, unsafe.Pointer(&p[0]), C.ulong(len(p)))
+	return int(n), err
+}
+
+// Close terminates the Slirp network.
+func (slirp *Slirp) Close() error {
+	rc, err := C.slirp_close(slirp.p)
+	if err != nil {
+		return err
+	}
+	if rc < 0 {
+		return fmt.Errorf("slirp_close returned status %d", rc)
+	}
+	// undocumented: rc > 0 is ok.
+	// (rc is the result of `writev(slirpdaemonfd[APPSIDE], iovout, 1)`)
+	return nil
+}
+
+func convertIP(ip net.IP) (C.struct_in_addr, error) {
+	var addr C.struct_in_addr
+	hostC := C.CString(ip.String())
+	rc, err := C.inet_pton(C.AF_INET, hostC, unsafe.Pointer(&addr))
+	C.free(unsafe.Pointer(hostC))
+	if err != nil {
+		return addr, err
+	}
+	if rc != 1 { // not rc != 0
+		return addr, fmt.Errorf("inet_pton returned status %d for ip %s", rc, ip)
+	}
+	return addr, nil
+}
+
+func convertIP6(ip net.IP) (C.struct_in6_addr, error) {
+	var addr C.struct_in6_addr
+	hostC := C.CString(ip.String())
+	rc, err := C.inet_pton(C.AF_INET6, hostC, unsafe.Pointer(&addr))
+	C.free(unsafe.Pointer(hostC))
+	if err != nil {
+		return addr, err
+	}
+	if rc != 1 { // not rc != 0
+		return addr, fmt.Errorf("inet_pton returned status %d for ip %s", rc, ip)
+	}
+	return addr, nil
+}
+
+// SetAddr sets the IPv4 address and the prefix.
+// SetAddr needs to be called before Start().
+// Use SetAddr6 for IPv6.
+func (slirp *Slirp) SetAddr(ipNet *net.IPNet) error {
+	if ipNet == nil {
+		return fmt.Errorf("unsupported IPNet %s", ipNet)
+	}
+	ip4 := ipNet.IP.To4()
+	if ip4 == nil {
+		return fmt.Errorf("unsupported IPNet %s", ipNet)
+	}
+	addr, err := convertIP(ip4)
+	if err != nil {
+		return err
+	}
+	prefix, _ := ipNet.Mask.Size()
+	rc, err := C.slirp_set_addr(slirp.p, addr, C.int(prefix))
+	if err != nil {
+		return err
+	}
+	if rc != 0 {
+		return fmt.Errorf("slirp_set_addr returned status %d", rc)
+	}
+	slirp.addr = ipNet
+	return nil
+}
+
+// Addr returns IPNet of the virtual network.
+// Use Addr6 for IPv6.
+func (slirp *Slirp) Addr() *net.IPNet {
+	return &net.IPNet{
+		IP:   slirp.addr.IP,
+		Mask: slirp.addr.Mask,
+	}
+}
+
+// SetAddr6 sets the IPv6 address and the prefix.
+// SetAddr6 needs to be called before Start().
+func (slirp *Slirp) SetAddr6(ipNet *net.IPNet) error {
+	if ipNet == nil || len(ipNet.IP) != net.IPv6len {
+		return fmt.Errorf("unsupported IPNet %s", ipNet)
+	}
+	addr, err := convertIP6(ipNet.IP)
+	if err != nil {
+		return err
+	}
+	prefix, _ := ipNet.Mask.Size()
+	rc, err := C.slirp_set_addr6(slirp.p, addr, C.int(prefix))
+	if err != nil {
+		return err
+	}
+	if rc != 0 {
+		return fmt.Errorf("slirp_set_addr6 returned status %d", rc)
+	}
+	slirp.addr6 = ipNet
+	return nil
+}
+
+// Addr6 returns IPNet of the virtual network. (IPv6)
+func (slirp *Slirp) Addr6() *net.IPNet {
+	return &net.IPNet{
+		IP:   slirp.addr6.IP,
+		Mask: slirp.addr6.Mask,
+	}
+}
+
+// SetDNSAddr sets the IPv4 DNS address.
+// SetDNSAddr needs to be called before Start().
+// Use SetDNSAddr6 for IPv6.
+func (slirp *Slirp) SetDNSAddr(ip net.IP) error {
+	ip4 := ip.To4()
+	if ip4 == nil {
+		return fmt.Errorf("unsupported IP %s", ip)
+	}
+	addr, err := convertIP(ip4)
+	if err != nil {
+		return err
+	}
+	rc, err := C.slirp_set_dnsaddr(slirp.p, addr)
+	if err != nil {
+		return err
+	}
+	if rc != 0 {
+		return fmt.Errorf("slirp_set_dnsaddr returned status %d", rc)
+	}
+	slirp.dnsaddr = ip
+	return nil
+}
+
+// DNSAddr returns the IPv4 DNS address.
+// Use DNSAddr6 for IPv6.
+func (slirp *Slirp) DNSAddr() net.IP {
+	return slirp.dnsaddr
+}
+
+// SetDNSAddr6 sets the IPv6 DNS address.
+// SetDNSAddr6 needs to be called before Start().
+func (slirp *Slirp) SetDNSAddr6(ip net.IP) error {
+	if len(ip) != net.IPv6len {
+		return fmt.Errorf("unsupported IP %s", ip)
+	}
+	addr, err := convertIP6(ip)
+	if err != nil {
+		return err
+	}
+	rc, err := C.slirp_set_dnsaddr6(slirp.p, addr)
+	if err != nil {
+		return err
+	}
+	if rc != 0 {
+		return fmt.Errorf("slirp_set_dnsaddr6 returned status %d", rc)
+	}
+	slirp.dnsaddr6 = ip
+	return nil
+}
+
+// DNSAddr6 returns the IPv6 DNS address.
+func (slirp *Slirp) DNSAddr6() net.IP {
+	return slirp.dnsaddr6
+}
+
+func isIPv4(s string) bool {
+	ip := net.ParseIP(s)
+	if ip == nil {
+		return false
+	}
+	return ip.To4() != nil
+}
+
+func convertNetAddr(na net.Addr) (C.struct_in_addr, C.int, error) {
+	var addr C.struct_in_addr
+	host, port, err := net.SplitHostPort(na.String())
+	if err != nil {
+		return addr, 0, err
+	}
+	if !isIPv4(host) {
+		return addr, 0, fmt.Errorf("non-IPv4 host: %s", host)
+	}
+	portN, err := strconv.Atoi(port)
+	if err != nil {
+		return addr, 0, err
+	}
+	hostC := C.CString(host)
+	rc, err := C.inet_pton(C.AF_INET, hostC, unsafe.Pointer(&addr))
+	C.free(unsafe.Pointer(hostC))
+	if err != nil {
+		return addr, 0, err
+	}
+	if rc != 1 { // not rc != 0
+		return addr, 0, fmt.Errorf("inet_pton returned status %d for host %s", rc, host)
+	}
+	return addr, C.int(portN), nil
+}
+
+// AddForward adds a host-to-guest port forwarding.
+//
+// Supports IPv6: no
+func (slirp *Slirp) AddForward(hostAddr, guestAddr net.Addr) error {
+	if hostAddr.Network() != guestAddr.Network() {
+		return fmt.Errorf("network mismatch: %s != %s", hostAddr.Network(), guestAddr.Network())
+	}
+	isUDP := C.int(0)
+	switch s := hostAddr.Network(); s {
+	case "tcp":
+		// NOP
+	case "udp":
+		isUDP = C.int(1)
+	default:
+		return fmt.Errorf("unsupported network: %s", s)
+	}
+	hostAddrC, hostPort, err := convertNetAddr(hostAddr)
+	if err != nil {
+		return err
+	}
+	guestAddrC, guestPort, err := convertNetAddr(guestAddr)
+	if err != nil {
+		return err
+	}
+	rc, err := C.slirp_add_fwd(slirp.p, isUDP, hostAddrC, hostPort, guestAddrC, guestPort)
+	if err != nil {
+		return err
+	}
+	if rc != 0 {
+		return fmt.Errorf("slirp_add_fwd returned status %d", rc)
+	}
+	slirp.forwards[hostAddr] = guestAddr
+	return nil
+}
+
+// Forwards returns a host-to-guest port forwarding map.
+func (slirp *Slirp) Forwards() map[net.Addr]net.Addr {
+	m := make(map[net.Addr]net.Addr, len(slirp.forwards))
+	for k, v := range slirp.forwards {
+		m[k] = v
+	}
+	return m
+}
+
+// AddUnixForward adds a forwarding for diverting a connection from a node of the
+// virtual network to guestAddr to the Unix socket bound to path on the host.
+//
+// Supports IPv6: no.
+func (slirp *Slirp) AddUnixForward(guestAddr net.Addr, path string) error {
+	guestAddrC, guestPort, err := convertNetAddr(guestAddr)
+	if err != nil {
+		return err
+	}
+	pathC := C.CString(path)
+	rc, err := C.slirp_add_unixfwd(slirp.p, guestAddrC, guestPort, pathC)
+	C.free(unsafe.Pointer(pathC))
+	if err != nil {
+		return err
+	}
+	if rc != 0 {
+		return fmt.Errorf("slirp_add_unixfwd returned status %d", rc)
+	}
+	slirp.unixForwards[guestAddr] = path
+	return nil
+}
+
+// UnixForwards returns an Unix forwarding map.
+func (slirp *Slirp) UnixForwards() map[net.Addr]string {
+	m := make(map[net.Addr]string, len(slirp.unixForwards))
+	for k, v := range slirp.unixForwards {
+		m[k] = v
+	}
+	return m
+}

--- a/src/libslirp_test.go
+++ b/src/libslirp_test.go
@@ -1,0 +1,158 @@
+package libslirp
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+)
+
+// we don't use github.com/gotestyourself/gotestyourself/assert
+// (Apache License 2.0 is not GPLv2-compatible)
+func assertNilError(t *testing.T, err error) {
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertDeepEqual(t *testing.T, expected, actual interface{}) {
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatalf("expected %+v, got %+v", expected, actual)
+	}
+}
+
+func newArpRequest(myMAC net.HardwareAddr, myIP, destIP net.IP) []byte {
+	buf := gopacket.NewSerializeBuffer()
+	opts := gopacket.SerializeOptions{
+		FixLengths:       true,
+		ComputeChecksums: true,
+	}
+	gopacket.SerializeLayers(buf, opts,
+		&layers.Ethernet{
+			SrcMAC:       myMAC,
+			DstMAC:       layers.EthernetBroadcast,
+			EthernetType: layers.EthernetTypeARP,
+		},
+		&layers.ARP{
+			AddrType:          layers.LinkTypeEthernet,
+			Protocol:          layers.EthernetTypeIPv4,
+			HwAddressSize:     6,
+			ProtAddressSize:   4,
+			Operation:         layers.ARPRequest,
+			SourceHwAddress:   []byte(myMAC),
+			SourceProtAddress: []byte(myIP),
+			DstHwAddress:      []byte{0, 0, 0, 0, 0, 0},
+			DstProtAddress:    []byte(destIP),
+		},
+	)
+	return buf.Bytes()
+}
+
+func recv(t *testing.T, r io.Reader) []byte {
+	maxMTU := 4096 // see libslirp.c MAX_MTU
+	maxBuf := make([]byte, maxMTU)
+	n, err := r.Read(maxBuf)
+	assertNilError(t, err)
+	return maxBuf[0:n]
+}
+
+// TestARP sends an ARP request to the default address (10.0.2.2) and verifies the ARP reply.
+func TestARP(t *testing.T) {
+	myMAC := net.HardwareAddr{0x02, 0x03, 0x04, 0x05, 0x06, 0x07}
+	myIP := net.IP{10, 0, 2, 100}
+	slirp, err := New(nil)
+	assertNilError(t, err)
+	assertNilError(t, slirp.Start())
+	testARP(t, slirp, myMAC, myIP)
+	assertNilError(t, slirp.Close())
+}
+
+// TestARPWithCustomAddr uses custom address.
+func TestARPWithCustomAddr(t *testing.T) {
+	ipNet := &net.IPNet{
+		IP:   net.IP{192, 168, 42, 1},
+		Mask: net.CIDRMask(20, 32),
+	}
+	slirp, err := New(nil)
+	assertNilError(t, err)
+	assertNilError(t, slirp.SetAddr(ipNet))
+	assertNilError(t, slirp.Start())
+	myMAC := net.HardwareAddr{0x02, 0x03, 0x04, 0x05, 0x06, 0x07}
+	myIP := net.IP{192, 168, 40, 200}
+	testARP(t, slirp, myMAC, myIP)
+	assertNilError(t, slirp.Close())
+}
+
+func testARP(t *testing.T, slirp *Slirp, myMAC net.HardwareAddr, myIP net.IP) {
+	gatewayIP := slirp.Addr().IP.To4()
+	t.Logf("gatewayIP=%+v,", []byte(gatewayIP))
+	// see slirp.c for 0x52, 0x55
+	gatewayMAC := net.HardwareAddr{0x52, 0x55, gatewayIP[0], gatewayIP[1], gatewayIP[2], gatewayIP[3]}
+	t.Logf("gatewayMAC=%s", gatewayMAC)
+	arpRequest := newArpRequest(myMAC, myIP, gatewayIP)
+	_, err := slirp.Write(arpRequest)
+	assertNilError(t, err)
+	arpReply := recv(t, slirp)
+	arpReplyPacket := gopacket.NewPacket(arpReply, layers.LayerTypeEthernet, gopacket.Default)
+	t.Log("got arp reply")
+	t.Log(arpReplyPacket.Dump())
+	arpReplyEthLayer := arpReplyPacket.Layer(layers.LayerTypeEthernet).(*layers.Ethernet)
+	assertDeepEqual(t, gatewayMAC, arpReplyEthLayer.SrcMAC)
+	assertDeepEqual(t, myMAC, arpReplyEthLayer.DstMAC)
+	assertDeepEqual(t, layers.EthernetTypeARP, arpReplyEthLayer.EthernetType)
+	assertDeepEqual(t, uint16(0), arpReplyEthLayer.Length)
+	arpReplyARPLayer := arpReplyPacket.Layer(layers.LayerTypeARP).(*layers.ARP)
+	assertDeepEqual(t, []byte(gatewayMAC), arpReplyARPLayer.SourceHwAddress)
+	assertDeepEqual(t, []byte(gatewayIP), arpReplyARPLayer.SourceProtAddress)
+	assertDeepEqual(t, []byte(myMAC), arpReplyARPLayer.DstHwAddress)
+	assertDeepEqual(t, []byte(myIP), arpReplyARPLayer.DstProtAddress)
+}
+
+func TestUDPForward(t *testing.T) {
+	// TODO: allow specifying custom hostUDPPort
+	hostUDPPort := 42424
+	guestUDPPort := 24242
+	guestMAC := net.HardwareAddr{0x02, 0x03, 0x04, 0x05, 0x06, 0x07}
+	guestIP := net.IP{10, 0, 2, 100}
+	testMessage := []byte("hello slirp udp forward")
+	slirp, err := New(nil)
+	assertNilError(t, err)
+	assertNilError(t, slirp.Start())
+	assertNilError(t, slirp.AddForward(&net.UDPAddr{
+		IP:   net.IP{127, 0, 0, 1},
+		Port: hostUDPPort,
+	},
+		&net.UDPAddr{
+			IP:   guestIP,
+			Port: guestUDPPort,
+		}))
+
+	// register guest to the table
+	gratuitousARPRequest := newArpRequest(guestMAC, guestIP, guestIP)
+	_, err = slirp.Write(gratuitousARPRequest)
+	assertNilError(t, err)
+	time.Sleep(100 * time.Millisecond)
+
+	// send testMessage to the hostUDPPort
+	udpConn, err := net.Dial("udp", fmt.Sprintf("127.0.0.1:%d", hostUDPPort))
+	assertNilError(t, err)
+	_, err = udpConn.Write(testMessage)
+	assertNilError(t, err)
+
+	// make sure the testMessage is forwarded to the guest via guestUDPPort
+	packetBytes := recv(t, slirp)
+	packet := gopacket.NewPacket(packetBytes, layers.LayerTypeEthernet, gopacket.Default)
+	t.Log("got forwarded udp packet")
+	t.Log(packet.Dump())
+	udpLayer := packet.Layer(layers.LayerTypeUDP).(*layers.UDP)
+	assertDeepEqual(t, guestUDPPort, int(udpLayer.DstPort))
+	assertDeepEqual(t, testMessage, udpLayer.Payload)
+
+	// done (TODO: reply to the host)
+	assertNilError(t, slirp.Close())
+}


### PR DESCRIPTION
Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>

@rd235 

FYI: my motivation of using libslirp is to enable NAT networking within unprivileged userns+netns+tap.
( https://github.com/jessfraz/img/issues/16 https://rootlesscontaine.rs/#o0-runtime )

cc @cyphar @jessfraz
