### PR TITLE
README.md: fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The library has been designed to assign suitable default values for all the para
 
 Libslirp provides functions to override the values (see <code>man libslirpcfg</code>).
 
-After the (eventual) configuration of all the parameters the slirp networj can be activated:
+After the (eventual) configuration of all the parameters the slirp network can be activated:
 ```
 slirp_start(myslirp);
 ```


### PR DESCRIPTION
a small typo found while working on https://github.com/giuseppe/slirp-forwarder

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>